### PR TITLE
Handle Transform objects in extract_exact_pk_value

### DIFF
--- a/rest_models/backend/compiler.py
+++ b/rest_models/backend/compiler.py
@@ -55,6 +55,10 @@ def extract_exact_pk_value(where):
     if len(where.children) == 2:
         exact, isnull = where.children
 
+        if isinstance(exact.lhs, Transform):
+            exact = exact.lhs.output_field
+        if isinstance(isnull.lhs, Transform):
+            isnull = isnull.lhs.output_field
         if (
             isinstance(exact, Exact) and isinstance(isnull, IsNull) and
             exact.lhs.target == isnull.lhs.target

--- a/rest_models/backend/compiler.py
+++ b/rest_models/backend/compiler.py
@@ -55,9 +55,9 @@ def extract_exact_pk_value(where):
     if len(where.children) == 2:
         exact, isnull = where.children
 
-        if isinstance(exact.lhs, Transform):
+        if hasattr(exact, 'lhs') and isinstance(exact.lhs, Transform):
             exact = exact.lhs.output_field
-        if isinstance(isnull.lhs, Transform):
+        if hasattr(isnull, 'lhs') and isinstance(isnull.lhs, Transform):
             isnull = isnull.lhs.output_field
         if (
             isinstance(exact, Exact) and isinstance(isnull, IsNull) and


### PR DESCRIPTION
I needed to patch this to handle queries of the form:

`JSONModel.objects.filter(jsonfield__property__isnull=False)`
