### PR TITLE
Make content type optional

### DIFF
--- a/rest_models/backend/compiler.py
+++ b/rest_models/backend/compiler.py
@@ -1050,7 +1050,7 @@ class SQLInsertCompiler(SQLCompiler):
                 file = fieldfile.name
 
                 if file is not None:  # field value can be None....
-                    files[field.column] = (file.name, file, file.content_type)
+                    files[field.column] = (file.name, file, getattr(file,'content_type',None))
                 else:
                     data[field.column] = None
             else:

--- a/rest_models/backend/compiler.py
+++ b/rest_models/backend/compiler.py
@@ -1299,7 +1299,7 @@ class SQLUpdateCompiler(SQLCompiler):
                     # str => we don't change it since it's not comming from our custom storage
                     pass
                 else:
-                    files[field.column] = (file.name, file, file.content_type)
+                    files[field.column] = (file.name, file, getattr(file,'content_type',None))
 
             else:
                 fieldname = field.concrete and field.db_column or field.name


### PR DESCRIPTION
This is to address #57.  We could also, instead of defaulting to None, set the default to 'application/octect-stream'.  Please provide feedback etc.