### PR TITLE
YPK-445

### DIFF
--- a/rest_models/backend/compiler.py
+++ b/rest_models/backend/compiler.py
@@ -1307,7 +1307,11 @@ class SQLUpdateCompiler(SQLCompiler):
                     # str => we don't change it since it's not comming from our custom storage
                     pass
                 else:
-                    files[field.column] = (file.name, file, file.content_type)
+                    try:
+                        files[field.column] = (file.name, file, file.content_type)
+                    except AttributeError:
+                        # This case happen when you create an image with a ContentFile() there is no 'content_type' in it
+                        files[field.column] = (file.name, file)
 
             else:
                 fieldname = field.concrete and field.db_column or field.name


### PR DESCRIPTION
- add exception handling for a special case
When you create a file with django.core.files.base.ContentFile there is no content_type thus raising `AttributeError: 'ContentFile' object has no attribute 'content_type'`
I made a try catch to be able to get my image to properly upload on the API